### PR TITLE
Fix multi-file context menu on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Additionally, I needed a way to compress videos under 5 MB to embed them into my
 * **Batch Processing**: Accepts individual files or directories (recursively searches for supported video extensions).
 * **Multithreaded Execution**: Utilizes `ThreadPoolExecutor` for parallel processing (up to 4 workers by default).
 * **Rich Progress Display**: Shows a real-time progress bar with estimated time remaining (powered by the [Rich](https://github.com/Textualize/rich) library).
-* **Windows Integration**: A `.bat` wrapper and a PowerShell installer script to add a **Compress video (FFmpeg)** entry to the Windows context menu.
+* **Windows Integration**: A `.bat` wrapper and a PowerShell installer script to add a **Compress video (FFmpeg)** entry to the Windows context menu. Selecting multiple files from Explorer sends them all to one console window.
 * **Drag-and-Drop GUI**: Launch the script without arguments (or with `--gui`) to open a drag-and-drop interface. Files convert in parallel with per-file progress percentages and an overall progress display.
 
 ## Supported Video Formats

--- a/compress.bat
+++ b/compress.bat
@@ -1,6 +1,6 @@
 @echo off
 pushd "%~dp0"
-python "%~dp0compress.py" "%*"
+python "%~dp0compress.py" %*
 set ec=%ERRORLEVEL%
 popd
 

--- a/win_install.ps1
+++ b/win_install.ps1
@@ -66,7 +66,7 @@ Set-ItemProperty -Path $baseKey -Name 'MultiSelectModel' -Value 'Player'
 # Define the command to run
 $cmdKey = "$baseKey\command"
 New-Item -Path $cmdKey -Force | Out-Null
-$command = "cmd.exe /c `"$bat`" %V"
+$command = "`"$bat`" %V"
 Set-ItemProperty -Path $cmdKey -Name '(Default)' -Value $command
 
 # Install ffmpeg via winget if missing


### PR DESCRIPTION
## Summary
- run compress.py with proper args from batch file
- call the batch script directly from the Windows context-menu installer
- document that multiple files open a single console window

## Testing
- `python -m py_compile compress.py`

------
https://chatgpt.com/codex/tasks/task_e_686cfc510e608326bbe77fb872d4cd99