### PR TITLE
Fix GUI launching from Start Menu

### DIFF
--- a/compress.bat
+++ b/compress.bat
@@ -1,6 +1,6 @@
 @echo off
 pushd "%~dp0"
-python "%~dp0compress.py" "%*"
+python "%~dp0compress.py" %*
 set ec=%ERRORLEVEL%
 popd
 


### PR DESCRIPTION
## Summary
- fix `compress.bat` argument quoting so launching without arguments opens the GUI

## Testing
- `pip install -r requirements.txt`
- `python compress.py --help`
- `python compress.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6870f10d01cc8326be24eaf05a70c486